### PR TITLE
French translation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,7 @@ class App extends Component<Props, State> {
           <h5 className="author">by Kevin Simler<br/>March 16, 2020</h5>
         </div>
         <div>
-          <span className="deemphasized">Translations: <a href="https://www.podemosaprender.org/brote/">español</a>, <a href="https://thecode.media/epidemic/">Русский язык</a></span>
+          <span className="deemphasized">Translations: <a href="https://www.podemosaprender.org/brote/">español</a>, <a href="https://thecode.media/epidemic/">Русский язык</a>, <a href="https://epidemie.schapira.dev/">français</a></span>
         </div>
         <div>
           <a href="https://twitter.com/Harry_Stevens">Harry Stevens</a> at The Washington Post recently published a <em>very</em> elegant simulation of how a disease like COVID-19 spreads. If you haven't already, I highly recommend <a href="https://www.washingtonpost.com/graphics/2020/world/corona-simulator/">checking it out</a>.


### PR DESCRIPTION
Fixes #4

I've replace links to external content with French translations of the same articles whenever possible. For other links, I've chosen to explicit "(en anglais)" ("in english") after the link title.

Some questions:

- I don't need analytics for myself, do you want me to keep yours, or would you prefer that I take them off?
- I've created a social network card slightly different from yours. We can homogenize if you provide me with a card like yours with "Épidémie" written on it instead of Outbreak.

If you have any question, feel free to ask!